### PR TITLE
Set Plugin name in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery-plugin",
+  "name": "jquery-sieve",
   "version": "0.0.0-ignored",
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
This will add some clarity when using package managers. They'll be able to reference the plugin by its distinctive name rather than the generic "jquery plugin" previously entered. 